### PR TITLE
Use images that are cached on GitHub's CDN

### DIFF
--- a/_plugins/image_cache.rb
+++ b/_plugins/image_cache.rb
@@ -1,0 +1,11 @@
+module Jekyll
+  class ImageCache < Jekyll::Generator
+    def generate(site)
+      site.collections['people'].docs.each do |person|
+        if person.data['image']
+          person.data['image'] = "https://theyworkforyou.github.io/uganda-images/Parliament/#{person.data['id']}.jpeg"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Rather than pulling the images from the official site, which can be slow and images can disappear without warning, we instead serve them from the [uganda-images](https://github.com/theyworkforyou/uganda-images) repository, which uses GitHub Pages' CDN.
