### PR TITLE
Add script for updating EVERYPOLITICIAN_DATASOURCE

### DIFF
--- a/_bin/update_datasource
+++ b/_bin/update_datasource
@@ -1,0 +1,13 @@
+#!/usr/bin/env ruby
+require 'json'
+require 'open-uri'
+require 'pry'
+
+countries = JSON.parse(open('https://github.com/everypolitician/everypolitician-data/raw/master/countries.json').read, symbolize_names: true)
+uganda = countries.find { |c| c[:slug] == 'Uganda' }
+parliament = uganda[:legislatures].first
+
+File.write('EVERYPOLITICIAN_DATASOURCE', parliament[:popolo_url])
+
+system('git add EVERYPOLITICIAN_DATASOURCE')
+system('git commit -m "Update EVERYPOLITICIAN_DATASOURCE"')


### PR DESCRIPTION
Sometimes this needs to be manually updated because the automatic
updater doesn't run properly. This script makes it simple to update the
datasource without having to manually go and lookup the correct popolo
url.

Fixes #33 
