### PR TITLE
Add term name and dates to post pages

### DIFF
--- a/_includes/term_navigation.html
+++ b/_includes/term_navigation.html
@@ -21,3 +21,16 @@
 </nav>
 {% endif %}
 
+{% assign current_term_membership = page.memberships | first %}
+{% assign current_term = current_term_membership.legislative_period %}
+
+<div class="page-header">
+  <h2>{{ current_term.name }}
+    {% if current_term.start_date or current_term.end_date %}
+    <small>
+      {% if current_term.start_date %}Start date: {{ current_term.start_date | date_to_long_string }}{% endif %}
+      {% if current_term.end_date %} End date: {{ current_term.end_date | date_to_long_string }}{% endif %}
+    </small>
+    {% endif %}
+  </h2>
+</div>


### PR DESCRIPTION
Adds a title section to the post pages showing which term the pages is showing and what the dates are for that term.

Fixes https://github.com/theyworkforyou/uganda-parliament-watch/issues/24

![screen shot 2016-05-06 at 13 33 02](https://cloud.githubusercontent.com/assets/22996/15071878/29c1f1ac-138f-11e6-81f4-6634a3ed659f.png)
![screen shot 2016-05-06 at 13 33 07](https://cloud.githubusercontent.com/assets/22996/15071880/2c9360f0-138f-11e6-8281-31396f4f72b7.png)
