### PR TITLE
Fix term page header

### DIFF
--- a/_layouts/events.html
+++ b/_layouts/events.html
@@ -2,8 +2,6 @@
 layout: default
 ---
 
-<h1>{{ page.name }}</h1>
-
 <ul>
   {% for membership in page.memberships %}
   <li><a href="{{ membership.person.url | prepend: site.baseurl }}">{{ membership.person.name }}</a></li>

--- a/_plugins/sort_events.rb
+++ b/_plugins/sort_events.rb
@@ -1,0 +1,7 @@
+class SortEvents < Jekyll::Generator
+  def generate(site)
+    site.collections['events'].docs.each do |event|
+      event.data['memberships'].sort_by! { |m| m['person'].data['name'] }
+    end
+  end
+end


### PR DESCRIPTION
Removes the duplicate header and sorts the list of people.

Fixes https://github.com/theyworkforyou/uganda-parliament-watch/issues/26

![screen shot 2016-05-06 at 15 07 51](https://cloud.githubusercontent.com/assets/22996/15073905/5a8b7bd4-139c-11e6-8b9d-a1e7f6f1785a.png)
