### PR TITLE
Remove "Post: " prefix on person position description

### DIFF
--- a/_layouts/current_mp.html
+++ b/_layouts/current_mp.html
@@ -9,7 +9,7 @@ layout: default
   <div class="page-header">
     <p>
     {% if person.current_membership.post %}
-    Post: <a href="{{ person.current_membership.post.url | prepend: site.baseurl }}">{{ person.current_membership.post.label }}</a>{% if person.current_membership.area %} for {{ person.current_membership.area.name }}{% endif %}.
+    <a href="{{ person.current_membership.post.url | prepend: site.baseurl }}">{{ person.current_membership.post.label }}</a>{% if person.current_membership.area %} for {{ person.current_membership.area.name }}{% endif %}.
     {% elsif person.current_membership.area %}
     Current MP for {{ person.current_membership.area.name }}.
     {% endif %}

--- a/_layouts/historic_mp.html
+++ b/_layouts/historic_mp.html
@@ -11,7 +11,7 @@ layout: default
     {% for membership in person.memberships %}
     <p>
     {% if membership.post %}
-    Post: <a href="{{ membership.post.url | prepend: site.baseurl }}">{{ membership.post.label }}</a>{% if membership.area %} for {{ membership.area.name }}{% endif %}.
+    <a href="{{ membership.post.url | prepend: site.baseurl }}">{{ membership.post.label }}</a>{% if membership.area %} for {{ membership.area.name }}{% endif %}.
     {% elsif membership.area %}
     MP for {{ membership.area.name }}.
     {% endif %}


### PR DESCRIPTION
The word "post" doesn't really mean much to the average website visitor,
so it's best to just leave it out completely.
![screen shot 2016-05-06 at 15 18 33](https://cloud.githubusercontent.com/assets/22996/15074160/d620ff52-139d-11e6-8050-9c97c850f4e1.png)

Follows on from https://github.com/theyworkforyou/uganda-parliament-watch/pull/39
