### PR TITLE
Nicer urls for district pages

### DIFF
--- a/_plugins/popolo.rb
+++ b/_plugins/popolo.rb
@@ -99,7 +99,7 @@ Jekyll::Popolo.process do |site, popolo|
   end
   districts = memberships_by_district.map do |id, memberships|
     {
-      'id' => id,
+      'id' => id.sub('ocd-division/country:ug/', '').gsub(/\w+\:/, ''),
       'title' => ocd_mapping[id] || id,
       'layout' => 'districts',
       'name' => ocd_mapping[id] || id,


### PR DESCRIPTION
Rather than using the full OCD ID this strips out the irrelevant bits to
make the slug a bit nicer.

Before: `/district/ocd-division-country-ug-region-northern-subregion-west-nile-district-adjumani/`
After: `/district/northern-west-nile-adjumani/`

Fixes https://github.com/theyworkforyou/uganda-parliament-watch/issues/29
